### PR TITLE
Remove hard-wired boost include path

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -1,5 +1,4 @@
 set( Boost_USE_MULTITHREADED ON)
-set( Boost_INCLUDE_DIR /usr/include )
 find_package( Boost 1.53.0 COMPONENTS atomic QUIET )
 if( Boost_ATOMIC_FOUND )
 	if( WITH_PYTHON STREQUAL "YES" )


### PR DESCRIPTION
This prevented FindBoost.cmake from locating the version installed from
Homebrew to /usr/local/include. FindBoost also has logic for MacPorts
too by the looks of it.
