### PR TITLE
Cure one final gettext link error on OS X

### DIFF
--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -1,20 +1,22 @@
 cmake_minimum_required( VERSION 2.6 FATAL_ERROR )
 
 include_directories(
-	"${PROJECT_SOURCE_DIR}/include" 
+	"${PROJECT_SOURCE_DIR}/include"
 	${PYTHON_INCLUDE_DIRS}
 	${Boost_INCLUDE_DIRS}
+	${Intl_INCLUDE_DIRS}
 )
 
 link_directories(
-        "${Boost_LIBRARY_DIRS}"
+	"${Boost_LIBRARY_DIRS}"
+	"${Intl_LIBRARY_DIRS}"
 	"${PROJECT_SOURCE_DIR}/src"
 	"${strusmodule_LIBRARY_DIRS}"
 	"${strusrpc_LIBRARY_DIRS}"
 )
 add_library( strus_python MODULE strusPythonModule.cpp bindingObjectsExt.cpp objInitializers.cpp )
 set_target_properties( strus_python PROPERTIES PREFIX "" OUTPUT_NAME strus)
-target_link_libraries( strus_python strus_bindings ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${Boost_Python_LIBRARIES} )
+target_link_libraries( strus_python strus_bindings ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${Boost_Python_LIBRARIES} ${Intl_LIBRARIES} )
 
 # FreeBSD needs kernel data access library for libuv (-libkvm)
 find_library( LIBKVM_LIBRARIES kvm )


### PR DESCRIPTION
Also fixes up a little tabs vs. space and trailing whitespace.
